### PR TITLE
Fix Truesight being used inside Quagmire

### DIFF
--- a/Model/Autobuff.cs
+++ b/Model/Autobuff.cs
@@ -94,9 +94,10 @@ namespace _4RTools.Model
                     }
                     foreach (var item in bmClone)
                     {
-                        if (foundQuag && (item.Key == EffectStatusIDs.CONCENTRATION || item.Key == EffectStatusIDs.INC_AGI))
+                        if (foundQuag && (item.Key == EffectStatusIDs.CONCENTRATION || item.Key == EffectStatusIDs.INC_AGI || item.Key == EffectStatusIDs.TRUESIGHT ))
                         {
-                            //NOT use Concentration neither INC_AGI Scroll when Quagmire is Found
+                            //NOT use Concentration, INC_AGI Scroll or TRUESIGHT when Quagmire is Found
+                            // In Hercules, Quagmire removes TRUESIGHT
                         }
                         else
                         {


### PR DESCRIPTION
Fix Truesight being used inside Quagmire. At least in hercules emulator, Quagmire removes Truesight