### PR TITLE
feat(ToggleApplicationStateForm): show error message when there is no client selected

### DIFF
--- a/Forms/ToggleApplicationStateForm.Designer.cs
+++ b/Forms/ToggleApplicationStateForm.Designer.cs
@@ -45,7 +45,7 @@
             this.groupBox1.Controls.Add(this.lblStatusToggle);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(178, 105);
+            this.groupBox1.Size = new System.Drawing.Size(178, 114);
             this.groupBox1.TabIndex = 25;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Current Status";
@@ -77,12 +77,15 @@
             // 
             // lblStatusToggle
             // 
+            this.lblStatusToggle.AllowDrop = true;
             this.lblStatusToggle.AutoSize = true;
             this.lblStatusToggle.Location = new System.Drawing.Point(35, 80);
+            this.lblStatusToggle.MaximumSize = new System.Drawing.Size(109, 30);
             this.lblStatusToggle.Name = "lblStatusToggle";
             this.lblStatusToggle.Size = new System.Drawing.Size(109, 13);
             this.lblStatusToggle.TabIndex = 22;
             this.lblStatusToggle.Text = "Press the key to start!";
+            this.lblStatusToggle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // notifyIconTray
             // 

--- a/Forms/ToggleApplicationStateForm.cs
+++ b/Forms/ToggleApplicationStateForm.cs
@@ -77,22 +77,33 @@ namespace _4RTools.Forms
         private bool toggleStatus()
         {
             bool isOn = this.btnStatusToggle.Text == "ON";
-            Console.WriteLine("toggleStatus" + isOn);
             if (isOn)
             {
                 this.btnStatusToggle.BackColor = Color.Red;
                 this.btnStatusToggle.Text = "OFF";
                 this.notifyIconTray.Icon = Resources.logo_4rtools_off;
                 this.subject.Notify(new Utils.Message(MessageCode.TURN_OFF, null));
+                this.lblStatusToggle.Text = "Press the key to start!";
                 new SoundPlayer(Resources.Speech_Off).Play();
             }
             else
             {
-                this.btnStatusToggle.BackColor = Color.Green;
-                this.btnStatusToggle.Text = "ON";
-                this.notifyIconTray.Icon = Resources.logo_4rtools_on;
-                this.subject.Notify(new Utils.Message(MessageCode.TURN_ON, null));
-                new SoundPlayer(Resources.Speech_On).Play();
+                Client client = ClientSingleton.GetClient();
+                if (client != null)
+                {
+                    this.btnStatusToggle.BackColor = Color.Green;
+                    this.btnStatusToggle.Text = "ON";
+                    this.notifyIconTray.Icon = Resources.logo_4rtools_on;
+                    this.subject.Notify(new Utils.Message(MessageCode.TURN_ON, null));
+                    this.lblStatusToggle.Text = "Press the key to stop!";
+                    this.lblStatusToggle.ForeColor = Color.Black;
+                    new SoundPlayer(Resources.Speech_On).Play();
+                } else
+                {
+                    this.lblStatusToggle.Text = "Please select a valid Ragnarok Client!";
+                    this.lblStatusToggle.ForeColor = Color.Red;
+                }
+                
             }
 
             return true;


### PR DESCRIPTION
### Summary
Show  an error message(not a dialog) and doesn't start the threads. Also toggle the labels(image bellow). close #61 


![image](https://user-images.githubusercontent.com/1382338/163075825-27a714e1-9183-4028-9710-4567ed22de94.png)
![image](https://user-images.githubusercontent.com/1382338/163075853-de5aef52-4162-40f2-897a-88d2bed3e6ff.png)
![image](https://user-images.githubusercontent.com/1382338/163075862-8e640c60-2c71-4750-b157-6a247ddaf6a2.png)
