### PR TITLE
feat: Making mouse flick mandatory in AHK and ATKxDEF

### DIFF
--- a/Model/AHK.cs
+++ b/Model/AHK.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Threading;
 using System.Windows.Input;
+using System.Drawing;
 using _4RTools.Utils;
 using Newtonsoft.Json;
 
@@ -30,7 +31,10 @@ namespace _4RTools.Model
         public bool mouseFlick { get; set; } = false;
         private _4RThread thread;
 
-        public AHK() { }
+
+        public AHK()
+        {
+        }
 
         public void Start()
         {
@@ -48,22 +52,27 @@ namespace _4RTools.Model
             foreach (KeyConfig config in ahkEntries.Values)
             {
                 Keys thisk = (Keys)Enum.Parse(typeof(Keys), config.key.ToString());
-                while (Keyboard.IsKeyDown(config.key))
+                if (!Keyboard.IsKeyDown(Key.LeftAlt) && !Keyboard.IsKeyDown(Key.RightAlt))
                 {
-                    if (!Keyboard.IsKeyDown(Key.LeftAlt) && !Keyboard.IsKeyDown(Key.RightAlt))
+                    if (config.clickActive && Keyboard.IsKeyDown(config.key))
                     {
-                        if (config.clickActive)
+                        while (Keyboard.IsKeyDown(config.key))
                         {
-                            if (mouseFlick) System.Windows.Forms.Cursor.Position = new System.Drawing.Point(System.Windows.Forms.Cursor.Position.X - 1, System.Windows.Forms.Cursor.Position.Y - 1);
                             Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_KEYDOWN_MSG_ID, thisk, 0);
                             Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_LBUTTONDOWN, 0, 0);
+                            System.Windows.Forms.Cursor.Position = new Point(System.Windows.Forms.Cursor.Position.X - Constants.MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK, System.Windows.Forms.Cursor.Position.Y - Constants.MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK);
                             Thread.Sleep(1);
+                            System.Windows.Forms.Cursor.Position = new Point(System.Windows.Forms.Cursor.Position.X + Constants.MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK, System.Windows.Forms.Cursor.Position.Y + Constants.MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK);
                             Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_LBUTTONUP, 0, 0);
-                            if (mouseFlick) System.Windows.Forms.Cursor.Position = new System.Drawing.Point(System.Windows.Forms.Cursor.Position.X + 1, System.Windows.Forms.Cursor.Position.Y + 1);
+                            Thread.Sleep(this.ahkDelay);
                         }
-                        else
+                    }
+                    else
+                    {
+                        while (Keyboard.IsKeyDown(config.key))
                         {
                             Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_KEYDOWN_MSG_ID, thisk, 0);
+                            Thread.Sleep(this.ahkDelay);
                         }
                     }
 

--- a/Model/ATKDEFMode.cs
+++ b/Model/ATKDEFMode.cs
@@ -2,12 +2,10 @@
 using Newtonsoft.Json;
 using _4RTools.Utils;
 using System.Threading;
+using System.Drawing;
 using System.Windows.Input;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace _4RTools.Model
 {
@@ -25,6 +23,7 @@ namespace _4RTools.Model
         public Key keySpammer { get; set; }
         public Dictionary<string,Key> defKeys { get; set; } = new Dictionary<string,Key>();
         public Dictionary<string,Key> atkKeys { get; set; } = new Dictionary<string, Key>();
+        private int PX_MOV = Constants.MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK;
 
         public string GetActionName()
         {
@@ -59,9 +58,12 @@ namespace _4RTools.Model
 
                 while (Keyboard.IsKeyDown(keySpammer))                
                 {
+
                     Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_KEYDOWN_MSG_ID, thisk, 0);
                     Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_LBUTTONDOWN, 0, 0);
+                    System.Windows.Forms.Cursor.Position = new Point(System.Windows.Forms.Cursor.Position.X - PX_MOV, System.Windows.Forms.Cursor.Position.Y - PX_MOV);
                     Thread.Sleep(1);
+                    System.Windows.Forms.Cursor.Position = new Point(System.Windows.Forms.Cursor.Position.X + PX_MOV, System.Windows.Forms.Cursor.Position.Y + PX_MOV);
                     Interop.PostMessage(roClient.process.MainWindowHandle, Constants.WM_LBUTTONUP, 0, 0);
                     Thread.Sleep(this.ahkDelay);
                 }

--- a/Utils/Constants.cs
+++ b/Utils/Constants.cs
@@ -19,5 +19,6 @@ namespace _4RTools.Utils
 
 
         public const int MINIMUM_HP_TO_RECOVER = 20;
+        public const int MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK = 1;
     }
 }


### PR DESCRIPTION
- Mouse flick is now mandatory
- Removing if inside spam loop
- Making AHK loop cleaner.