### PR TITLE
Refactor/autobuff thread

### DIFF
--- a/4RTools.csproj
+++ b/4RTools.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Model\Autopot.cs" />
     <Compile Include="Model\Autobuff.cs" />
     <Compile Include="Model\AutoRefreshSpammer.cs" />
+    <Compile Include="Model\StatusRecovery.cs" />
     <Compile Include="Model\UserPreferences.cs" />
     <Compile Include="Model\Hexed.cs" />
     <Compile Include="Model\Action.cs" />

--- a/Forms/SkillAutoBuffForm.cs
+++ b/Forms/SkillAutoBuffForm.cs
@@ -24,14 +24,14 @@ namespace _4RTools.Forms
             switch ((subject as Subject).Message.code)
             {
                 case MessageCode.PROFILE_CHANGED:
-                    Dictionary<EffectStatusIDs, Key> buffMappingClone = new Dictionary<EffectStatusIDs, Key>(ProfileSingleton.GetCurrent().SkillAutoBuff.buffMapping);
+                    Dictionary<EffectStatusIDs, Key> buffMappingClone = new Dictionary<EffectStatusIDs, Key>(ProfileSingleton.GetCurrent().Autobuff.buffMapping);
                     this.updateInputValues(buffMappingClone);
                     break;
                 case MessageCode.TURN_OFF:
-                    ProfileSingleton.GetCurrent().SkillAutoBuff.Stop();
+                    ProfileSingleton.GetCurrent().Autobuff.Stop();
                     break;
                 case MessageCode.TURN_ON:
-                    ProfileSingleton.GetCurrent().SkillAutoBuff.Start();
+                    ProfileSingleton.GetCurrent().Autobuff.Start();
                     break;
             }
         }
@@ -74,8 +74,8 @@ namespace _4RTools.Forms
                 {
                     Key key = (Key)Enum.Parse(typeof(Key), txtBox.Text.ToString());
                     EffectStatusIDs statusID = (EffectStatusIDs)Int16.Parse(txtBox.Name.Split(new[] { "in" }, StringSplitOptions.None)[1]);
-                    ProfileSingleton.GetCurrent().SkillAutoBuff.AddKeyToBuff(statusID, key);
-                    ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().SkillAutoBuff);
+                    ProfileSingleton.GetCurrent().Autobuff.AddKeyToBuff(statusID, key);
+                    ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().Autobuff);
                 }
             }
             catch { }

--- a/Forms/StatusEffectForm.cs
+++ b/Forms/StatusEffectForm.cs
@@ -26,16 +26,16 @@ namespace _4RTools.Forms
             switch ((subject as Subject).Message.code)
             {
                 case MessageCode.PROFILE_CHANGED:
-                    if (ProfileSingleton.GetCurrent().StatusAutoBuff.buffMapping.Count > 0){
+                    if (ProfileSingleton.GetCurrent().StatusRecovery.buffMapping.Count > 0){
                         //For Status, the key is the same for each status, so don't matter which status i'm based to update combo box value.
-                        this.txtStatusKey.Text = ProfileSingleton.GetCurrent().StatusAutoBuff.buffMapping[EffectStatusIDs.SILENCE].ToString();
+                        this.txtStatusKey.Text = ProfileSingleton.GetCurrent().StatusRecovery.buffMapping[EffectStatusIDs.SILENCE].ToString();
                     }
                     break;
                 case MessageCode.TURN_OFF:
-                    ProfileSingleton.GetCurrent().StatusAutoBuff.Stop();
+                    ProfileSingleton.GetCurrent().StatusRecovery.Stop();
                     break;
                 case MessageCode.TURN_ON:
-                    ProfileSingleton.GetCurrent().StatusAutoBuff.Start();
+                    ProfileSingleton.GetCurrent().StatusRecovery.Start();
                     break;
             }
         }
@@ -44,15 +44,15 @@ namespace _4RTools.Forms
         {
             Key k = (Key)Enum.Parse(typeof(Key), this.txtStatusKey.Text.ToString());
 
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.POISON, k);
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.SILENCE, k);
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.BLIND, k);
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.CONFUSION, k);
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.HALLUCINATIONWALK, k);
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.HALLUCINATION, k);
-            ProfileSingleton.GetCurrent().StatusAutoBuff.AddKeyToBuff(EffectStatusIDs.CURSE, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.POISON, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.SILENCE, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.BLIND, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.CONFUSION, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.HALLUCINATIONWALK, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.HALLUCINATION, k);
+            ProfileSingleton.GetCurrent().StatusRecovery.AddKeyToBuff(EffectStatusIDs.CURSE, k);
 
-            ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().StatusAutoBuff);
+            ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().StatusRecovery);
         }
     }
 }

--- a/Forms/StuffAutoBuffForm.cs
+++ b/Forms/StuffAutoBuffForm.cs
@@ -21,14 +21,14 @@ namespace _4RTools.Forms
             switch ((subject as Subject).Message.code)
             {
                 case MessageCode.PROFILE_CHANGED:
-                    Dictionary<EffectStatusIDs, Key> buffMappingClone = new Dictionary<EffectStatusIDs, Key>(ProfileSingleton.GetCurrent().ItemsAutoBuff.buffMapping);
+                    Dictionary<EffectStatusIDs, Key> buffMappingClone = new Dictionary<EffectStatusIDs, Key>(ProfileSingleton.GetCurrent().Autobuff.buffMapping);
                     this.updateInputValues(buffMappingClone);
                     break;
                 case MessageCode.TURN_OFF:
-                    ProfileSingleton.GetCurrent().ItemsAutoBuff.Stop();
+                    ProfileSingleton.GetCurrent().Autobuff.Stop();
                     break;
                 case MessageCode.TURN_ON:
-                    ProfileSingleton.GetCurrent().ItemsAutoBuff.Start();
+                    ProfileSingleton.GetCurrent().Autobuff.Start();
                     break;
             }
         }
@@ -65,8 +65,8 @@ namespace _4RTools.Forms
                 if (txtBox.Text.ToString() != String.Empty) {
                     Key key = (Key)Enum.Parse(typeof(Key), txtBox.Text.ToString());
                     EffectStatusIDs statusID = (EffectStatusIDs)Int16.Parse(txtBox.Name.Split(new[] { "in" }, StringSplitOptions.None)[1]);
-                    ProfileSingleton.GetCurrent().ItemsAutoBuff.AddKeyToBuff(statusID, key);
-                    ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().ItemsAutoBuff);
+                    ProfileSingleton.GetCurrent().Autobuff.AddKeyToBuff(statusID, key);
+                    ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().Autobuff);
                 }
                 
             }

--- a/Model/Hexed.cs
+++ b/Model/Hexed.cs
@@ -183,6 +183,7 @@ namespace _4RTools.Model
             clients.Add(new Client("rtales.bin", 0x00E8E434, 0x00E90C00));
             clients.Add(new Client("Jogar", 0x00E8E434, 0x00E90C00));
             clients.Add(new Client("RagnaRotico",0x00E4CAF4, 0x00E4D768));
+            clients.Add(new Client("BattleOfSEARO",0x00E4CAF4, 0x00E4D768));
             clients.Add(new Client("EasyRO",0x010DCE10, 0x010DF5D8));
             clients.Add(new Client("Jogar",0x0101A700, 0x0101CEB0)); //Portal Kafra
             clients.Add(new Client("ragna4th",0x011D1A04, 0x011D43E8));
@@ -194,7 +195,6 @@ namespace _4RTools.Model
             clients.Add(new Client("BlueRO",0x011D1A04, 0x011D43E8));
             clients.Add(new Client("StreetRO 2.0",0x010DCE10, 0x010D5DA8));
             clients.Add(new Client("Gladius", 0x010DCE10, 0x010DF5D8));
-            clients.Add(new Client("BattleOfSEARO", 0x00E4CAF4, 0x00E461A0));
 
             return clients;
         }

--- a/Model/Profile.cs
+++ b/Model/Profile.cs
@@ -25,10 +25,9 @@ namespace _4RTools.Model
                     profile.AHK = JsonConvert.DeserializeObject<AHK>(Profile.GetByAction(rawObject, profile.AHK));
                     profile.Autopot = JsonConvert.DeserializeObject<Autopot>(Profile.GetByAction(rawObject, profile.Autopot));
                     profile.AutopotYgg = JsonConvert.DeserializeObject<Autopot>(Profile.GetByAction(rawObject, profile.AutopotYgg));
-                    profile.StatusAutoBuff = JsonConvert.DeserializeObject<AutoBuff>(Profile.GetByAction(rawObject, profile.StatusAutoBuff));
+                    profile.StatusRecovery = JsonConvert.DeserializeObject<StatusRecovery>(Profile.GetByAction(rawObject, profile.StatusRecovery));
                     profile.AutoRefreshSpammer = JsonConvert.DeserializeObject<AutoRefreshSpammer>(Profile.GetByAction(rawObject, profile.AutoRefreshSpammer));
-                    profile.ItemsAutoBuff = JsonConvert.DeserializeObject<AutoBuff>(Profile.GetByAction(rawObject, profile.ItemsAutoBuff));
-                    profile.SkillAutoBuff = JsonConvert.DeserializeObject<AutoBuff>(Profile.GetByAction(rawObject, profile.SkillAutoBuff));
+                    profile.Autobuff = JsonConvert.DeserializeObject<AutoBuff>(Profile.GetByAction(rawObject, profile.Autobuff));
                     profile.SongMacro = JsonConvert.DeserializeObject<Macro>(Profile.GetByAction(rawObject, profile.SongMacro));
                     profile.AtkDefMode = JsonConvert.DeserializeObject<ATKDEFMode>(Profile.GetByAction(rawObject, profile.AtkDefMode));
                     profile.MacroSwitch = JsonConvert.DeserializeObject<Macro>(Profile.GetByAction(rawObject, profile.MacroSwitch));
@@ -92,9 +91,8 @@ namespace _4RTools.Model
         public Autopot Autopot { get; set; }
         public Autopot AutopotYgg { get; set; }
         public AutoRefreshSpammer AutoRefreshSpammer { get; set; }
-        public AutoBuff StatusAutoBuff { get; set; }
-        public AutoBuff ItemsAutoBuff { get; set; }
-        public AutoBuff SkillAutoBuff { get; set; }
+        public AutoBuff Autobuff { get; set; }
+        public StatusRecovery StatusRecovery { get; set; }
         public Macro SongMacro { get; set;}
         public Macro MacroSwitch { get; set;}
 
@@ -109,9 +107,8 @@ namespace _4RTools.Model
             this.Autopot = new Autopot(Autopot.ACTION_NAME_AUTOPOT);
             this.AutopotYgg = new Autopot(Autopot.ACTION_NAME_AUTOPOT_YGG);
             this.AutoRefreshSpammer = new AutoRefreshSpammer();
-            this.StatusAutoBuff = new AutoBuff(AutoBuff.ACTION_NAME_STATUS_AUTOBUFF);
-            this.ItemsAutoBuff = new AutoBuff(AutoBuff.ACTION_NAME_ITEM_AUTOBUFF);
-            this.SkillAutoBuff = new AutoBuff(AutoBuff.ACTION_NAME_SKILL_AUTOBUFF);
+            this.Autobuff = new AutoBuff();
+            this.StatusRecovery = new StatusRecovery();
             this.SongMacro = new Macro(Macro.ACTION_NAME_SONG_MACRO,MacroSongForm.TOTAL_MACRO_LANES_FOR_SONGS);
             this.MacroSwitch = new Macro(Macro.ACTION_NAME_MACRO_SWITCH, MacroSwitchForm.TOTAL_MACRO_LANES);
             this.AtkDefMode = new ATKDEFMode();

--- a/Model/StatusRecovery.cs
+++ b/Model/StatusRecovery.cs
@@ -1,0 +1,94 @@
+﻿using _4RTools.Utils;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Windows.Input;
+
+namespace _4RTools.Model
+{
+    public class StatusRecovery : Action
+    {
+        public static string ACTION_NAME_STATUS_AUTOBUFF = "StatusAutoBuff";
+
+        private _4RThread thread;
+        public Dictionary<EffectStatusIDs, Key> buffMapping = new Dictionary<EffectStatusIDs, Key>();
+        public int delay { get; set; } = 1;
+
+        public string GetActionName()
+        {
+            return ACTION_NAME_STATUS_AUTOBUFF;
+        }
+
+        public _4RThread RestoreStatusThread(Client c)
+        {
+            Client roClient = ClientSingleton.GetClient();
+            _4RThread statusEffectsThread = new _4RThread(_ =>
+            {
+                for (int i = 1; i <= Constants.MAX_BUFF_LIST_INDEX_SIZE - 1; i++)
+                {
+                    uint currentStatus = c.CurrentBuffStatusCode(i);
+                    EffectStatusIDs status = (EffectStatusIDs)currentStatus;
+                    if (buffMapping.ContainsKey((EffectStatusIDs)currentStatus)) //IF FOR REMOVE STATUS - CHECK IF STATUS EXISTS IN STATUS LIST AND DO ACTION
+                    {
+                        //IF CONTAINS CURRENT STATUS ON DICT
+                        Key key = buffMapping[(EffectStatusIDs)currentStatus];
+                        if (Enum.IsDefined(typeof(EffectStatusIDs), currentStatus))
+                        {
+                            this.useStatusRecovery(key);
+                        }
+                    }
+                }
+                Thread.Sleep(this.delay);
+                return 0;
+            });
+
+            return statusEffectsThread;
+        }
+
+        public string GetConfiguration()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+
+        public void Start()
+        {
+            Stop();
+            Client roClient = ClientSingleton.GetClient();
+            if (roClient != null)
+            {
+                this.thread = RestoreStatusThread(roClient);
+                _4RThread.Start(this.thread);
+            }
+        }
+
+        public void AddKeyToBuff(EffectStatusIDs status, Key key)
+        {
+            if (buffMapping.ContainsKey(status))
+            {
+                buffMapping.Remove(status);
+            }
+
+            if (FormUtils.IsValidKey(key))
+            {
+                buffMapping.Add(status, key);
+            }
+        }
+
+        public void Stop()
+        {
+            _4RThread.Stop(this.thread);
+        }
+
+        private void useStatusRecovery(Key key)
+        {
+            if ((key != Key.None) && !Keyboard.IsKeyDown(Key.LeftAlt) && !Keyboard.IsKeyDown(Key.RightAlt))
+                Interop.PostMessage(ClientSingleton.GetClient().process.MainWindowHandle, Constants.WM_KEYDOWN_MSG_ID, (Keys)Enum.Parse(typeof(Keys), key.ToString()), 0);
+        }
+
+    }
+}

--- a/Utils/Constants.cs
+++ b/Utils/Constants.cs
@@ -20,5 +20,6 @@ namespace _4RTools.Utils
 
         public const int MINIMUM_HP_TO_RECOVER = 20;
         public const int MOUSE_DIAGONAL_MOVIMENTATION_PIXELS_AHK = 1;
+        public const int MAX_BUFF_LIST_INDEX_SIZE = 100;
     }
 }

--- a/Utils/FormUtils.cs
+++ b/Utils/FormUtils.cs
@@ -32,6 +32,11 @@ namespace _4RTools.Utils
             catch { }
         }
 
+        public static bool IsValidKey(Key key)
+        {
+            return (key != Key.Back && key != Key.Escape && key != Key.None);
+        }
+
         public static void OnKeyPress(object sender, KeyPressEventArgs e)
         {
             e.Handled = true;

--- a/Utils/_4RThread.cs
+++ b/Utils/_4RThread.cs
@@ -41,9 +41,9 @@ namespace _4RTools.Utils
         {
             if (_4RThread != null && _4RThread.thread.IsAlive)
             {
-                try
-                {
-                    _4RThread.thread.Suspend();
+                try { 
+                
+                    _4RThread.thread.Abort();
                 }
                 catch (Exception ex) {
                     Console.WriteLine("[4R Thread Exception] =========== We could not suspend curren thread: " + ex);


### PR DESCRIPTION
- Moving StatusRecovery for a new class to make debug easier
- Unifying AutobuffItem and AutobuffStuff in a new key called `Autobuff`, and the same thread is used to make Autobuff in general.
- Fix: Name Adress of BattleOfSeaRO (Pinoy)
- Using `Thread.Abort()` instead of deprecated method `Thread.Suspend()` to finish threads correctly.