### PR TITLE
Forca Violenta e Forca Violentissima

### DIFF
--- a/Model/Autobuff.cs
+++ b/Model/Autobuff.cs
@@ -22,7 +22,7 @@ namespace _4RTools.Model
             Stop();
             Client roClient = ClientSingleton.GetClient();
             if (roClient != null)
-            {  
+            {
                  this.thread = AutoBuffThread(roClient);
                 _4RThread.Start(this.thread);
             }
@@ -40,6 +40,14 @@ namespace _4RTools.Model
                     uint currentStatus = c.CurrentBuffStatusCode(i);
                     EffectStatusIDs status = (EffectStatusIDs)currentStatus;
 
+                    if (status == EffectStatusIDs.OVERTHRUSTMAX)
+                    {
+                        if (buffMapping.ContainsKey(EffectStatusIDs.OVERTHRUST))
+                        {
+                            bmClone.Remove(EffectStatusIDs.OVERTHRUST);
+                        }
+                    }
+
                     if (buffMapping.ContainsKey(status)) //CHECK IF STATUS EXISTS IN STATUS LIST AND DO ACTION
                     {
                         bmClone.Remove(status);
@@ -50,7 +58,7 @@ namespace _4RTools.Model
 
                 foreach (var item in bmClone)
                 {
-                    if (foundQuag && (item.Key == EffectStatusIDs.CONCENTRATION || item.Key == EffectStatusIDs.INC_AGI || item.Key == EffectStatusIDs.TRUESIGHT))
+                    if (foundQuag && (item.Key == EffectStatusIDs.CONCENTRATION || item.Key == EffectStatusIDs.INC_AGI || item.Key == EffectStatusIDs.TRUESIGHT || item.Key == EffectStatusIDs.ADRENALINE))
                     {
                         break;
                     }


### PR DESCRIPTION
**Model/Autobuff.cs**
**Linha 43**
Corrigindo a interação entre Força Violenta e Força Violentíssima. O jogo base nos deixa sobrescrever Força Violenta com Força Violentíssima mas não deixa o contrário ser feito. Deste modo, na situação específica em que Força Violenta estava configurada como um Autobuff e Força Violentíssima era usada um loop se iniciava em que Força Violenta era usada através do 4RTools até que o buff de Força Violentíssima acabasse.
Esta modificação atua exclusivamente no cenário em que Força Violentíssima é um buff ativo **E** Força Violenta possui uma keybind no Autobuff. Neste cenário, a keybind de Força Violenta é removida da pilha de execução.

**Linha 61**
Adicionando a habilidade Adrenalina Pura à lista de habilidades que não devem ser utilizadas quando o usuário estiver dentro de uma área de Pântano dos Mortos.