### PR TITLE
feat(SkillTimer): fix loading key from json

### DIFF
--- a/Forms/SkillTimerForm.cs
+++ b/Forms/SkillTimerForm.cs
@@ -27,9 +27,13 @@ namespace _4RTools.Forms
             switch ((subject as Subject).Message.code)
             {
                 case MessageCode.PROFILE_CHANGED:
+                    string skillTimerKey = ProfileSingleton.GetCurrent().AutoRefreshSpammer.refreshKey.ToString();
+                    string autoRefreshDelay = ProfileSingleton.GetCurrent().AutoRefreshSpammer.refreshDelay.ToString();
+                    
                     FormUtils.ResetForm(this);
-                    this.txtSkillTimerKey.Text = ProfileSingleton.GetCurrent().AutoRefreshSpammer.refreshKey.ToString();
-                    this.txtAutoRefreshDelay.Text = ProfileSingleton.GetCurrent().AutoRefreshSpammer.refreshDelay.ToString();
+
+                    this.txtSkillTimerKey.Text = skillTimerKey;
+                    this.txtAutoRefreshDelay.Text = autoRefreshDelay;
                     break;
                 case MessageCode.TURN_ON:
                     ProfileSingleton.GetCurrent().AutoRefreshSpammer.Start();


### PR DESCRIPTION
When the ResetForm is called, it cleans up the Skill Timer Key and Delay, in order to fulfill with the Profile. 

However, when changing the key value, the Profile Saving Function is triggered, causing the Key value to be None.